### PR TITLE
处理子目录下的文件；保留 html 注释。

### DIFF
--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -89,6 +89,7 @@ function htmlToWxml(opts){
 			.pipe(htmltidy({
 	      'output-xml': true,
 	      'drop-empty-elements': false,
+	      'hideComments': false,
 	      indent: true,
 	    }))
 			.pipe(replace(rmTagReg(htmlToWxml['rmTag']), ''))
@@ -153,8 +154,8 @@ module.exports = function(from, to, conf) {
 	}
 	
 	var opts = {
-		html: path.join(from, '*.html'),
-		css: path.join(from, '*.css'),
+		html: path.join(from, '**/*.html'),
+		css: path.join(from, '**/*.css'),
 		assets: path.join(from, '**/*.+('+ config.assets +')'),
 		dist: to
 	}


### PR DESCRIPTION
很有用的工具，感谢辛巴 @Simbachen 分享😄

解决了两个自己遇到的问题，还有一些后续有空再看。

- css 头部的 `@charset "UTF-8"` 需要去除；
- css ``*`` 选择器需要去除，貌似 wxss 禁用了。

wxss 里出现这两个都会报 ``unexpected token``错误。